### PR TITLE
Adds PolicyExecutor

### DIFF
--- a/table_rl/explorers/__init__.py
+++ b/table_rl/explorers/__init__.py
@@ -2,3 +2,4 @@ from table_rl.explorers.epsilon_greedy import ConstantEpsilonGreedy
 from table_rl.explorers.epsilon_greedy import LinearDecayEpsilonGreedy
 from table_rl.explorers.epsilon_greedy import PercentageDecayEpsilonGreedy
 from table_rl.explorers.greedy import GreedyExplorer
+from table_rl.explorers.policy_executor import PolicyExecutor

--- a/table_rl/explorers/policy_executor.py
+++ b/table_rl/explorers/policy_executor.py
@@ -1,0 +1,33 @@
+import numpy as np
+from table_rl import explorer
+from pdb import set_trace
+
+
+class PolicyExecutor(explorer.Explorer):
+    """Executes a specific policy
+
+    Args:
+      policy: 2D numpy array where policy[state,action] is the pi(a|s)
+    """
+
+    def __init__(self, policy):
+        self.policy = policy
+
+
+    def select_action(self, obs, action_values) -> int:
+        return np.random.choice(self.policy.shape[1], p=self.policy[obs])
+
+
+    def observe(self, obs, reward, terminated, truncated):
+        """Select an action.
+
+        Args:
+          obs: next state/observation
+          reward: reward received
+          terminated: bool indicating environment termination
+          truncated: bool indicating epsisode truncation
+        """
+        pass
+
+
+

--- a/tests/test_explorers.py
+++ b/tests/test_explorers.py
@@ -37,3 +37,23 @@ class TestEpsilonGreedyExplorers:
             assert math.isclose(actual_epsilon, expected_epsilon)
             explorer.observe(None, None, None, None)
 
+
+class TestPolicyExecutor:
+
+    def test_policy_executor(self):
+        policy = np.array([[0.3, 0.7],
+                           [0.2, 0.8],
+                           [0.4, 0.6]])
+        explorer = table_rl.explorers.PolicyExecutor(policy)
+        actions = [explorer.select_action(0, None) for _ in range(500)]
+        assert 0 in actions
+        assert 1 in actions
+        assert 2 not in actions
+        policy = np.array([[0.0, 1.0],
+                   [0.2, 0.8],
+                   [0.4, 0.6]])
+        explorer = table_rl.explorers.PolicyExecutor(policy)
+        actions = [explorer.select_action(0, None) for _ in range(500)]
+        assert all(action == 1 for action in actions)
+      
+


### PR DESCRIPTION
A PolicyExecutor is an explorer that executes a given policy provided as a 2D numpy array where `policy[s,a]` is pi(a|s).