### PR TITLE
Adds training_mode to explorer's `observe` method

### DIFF
--- a/table_rl/explorer.py
+++ b/table_rl/explorer.py
@@ -13,13 +13,14 @@ class Explorer(object, metaclass=ABCMeta):
         """
         raise NotImplementedError()
 
-    def observe(self, obs, reward, terminated, truncated):
+    def observe(self, obs, reward, terminated, truncated, training_mode):
         """Select an action.
 
         Args:
           obs: next state/observation
           reward: reward received
           terminated: bool indicating environment termination
-          truncated: bool indicating epsisode truncation
+          truncated: bool indicating episode truncation
+          training_mode: bool indicating whether the agent is training
         """
         raise NotImplementedError()

--- a/table_rl/explorers/epsilon_greedy.py
+++ b/table_rl/explorers/epsilon_greedy.py
@@ -33,14 +33,15 @@ class ConstantEpsilonGreedy(explorer.Explorer):
     def select_action(self, obs, action_values) -> int:
         return select_epsilon_greedy_action(self.epsilon, action_values, self.num_actions)
 
-    def observe(self, obs, reward, terminated, truncated):
+    def observe(self, obs, reward, terminated, truncated, training_mode):
         """Select an action.
 
         Args:
           obs: next state/observation
           reward: reward received
           terminated: bool indicating environment termination
-          truncated: bool indicating epsisode truncation
+          truncated: bool indicating episode truncation
+          training_mode: bool indicating whether the agent is training
         """
         pass
 
@@ -68,16 +69,18 @@ class LinearDecayEpsilonGreedy(explorer.Explorer):
     def select_action(self, obs, action_values) -> int:
         return select_epsilon_greedy_action(self.epsilon, action_values, self.num_actions)
 
-    def observe(self, obs, reward, terminated, truncated):
+    def observe(self, obs, reward, terminated, truncated, training_mode):
         """Select an action.
 
         Args:
           obs: next state/observation
           reward: reward received
           terminated: bool indicating environment termination
-          truncated: bool indicating epsisode truncation
+          truncated: bool indicating episode truncation
+          training_mode: bool indicating whether the agent is training
         """
-        self.epsilon = max(self.epsilon_end, self.epsilon - self.decay_value)
+        if training_mode:
+            self.epsilon = max(self.epsilon_end, self.epsilon - self.decay_value)
 
 
 class PercentageDecayEpsilonGreedy(explorer.Explorer):
@@ -99,14 +102,16 @@ class PercentageDecayEpsilonGreedy(explorer.Explorer):
     def select_action(self, obs, action_values) -> int:
         return select_epsilon_greedy_action(self.epsilon, action_values, self.num_actions)
 
-    def observe(self, obs, reward, terminated, truncated):
+    def observe(self, obs, reward, terminated, truncated, training_mode):
         """Select an action.
 
         Args:
           obs: next state/observation
           reward: reward received
           terminated: bool indicating environment termination
-          truncated: bool indicating epsisode truncation
+          truncated: bool indicating episode truncation
+          training_mode: bool indicating whether the agent is training
         """
-        self.epsilon = max(self.min_epsilon, self.epsilon * self.decay_percentage)
+        if training_mode:
+            self.epsilon = max(self.min_epsilon, self.epsilon * self.decay_percentage)
 

--- a/table_rl/explorers/greedy.py
+++ b/table_rl/explorers/greedy.py
@@ -17,13 +17,14 @@ class GreedyExplorer(explorer.Explorer):
         action = np.random.choice(best_action_indices)
         return action
 
-    def observe(self, obs, reward, terminated, truncated):
+    def observe(self, obs, reward, terminated, truncated, training_mode):
         """Select an action.
 
         Args:
           obs: next state/observation
           reward: reward received
           terminated: bool indicating environment termination
-          truncated: bool indicating epsisode truncation
+          truncated: bool indicating episode truncation
+          training_mode: bool indicating whether the agent is training
         """
         pass

--- a/table_rl/explorers/policy_executor.py
+++ b/table_rl/explorers/policy_executor.py
@@ -18,7 +18,7 @@ class PolicyExecutor(explorer.Explorer):
         return np.random.choice(self.policy.shape[1], p=self.policy[obs])
 
 
-    def observe(self, obs, reward, terminated, truncated):
+    def observe(self, obs, reward, terminated, truncated, training_mode):
         """Select an action.
 
         Args:
@@ -26,6 +26,7 @@ class PolicyExecutor(explorer.Explorer):
           reward: reward received
           terminated: bool indicating environment termination
           truncated: bool indicating epsisode truncation
+          training_mode: bool indicating whether the agent is training
         """
         pass
 

--- a/table_rl/learners/double_q_learning.py
+++ b/table_rl/learners/double_q_learning.py
@@ -49,7 +49,7 @@ class DoubleQLearning(learner.Learner):
             None
         """
         self.update_q(self.current_obs, self.last_action, reward, terminated, obs)
-        self.explorer.observe(obs, reward, terminated, truncated)
+        self.explorer.observe(obs, reward, terminated, truncated, training_mode)
         if terminated or truncated:
             self.current_obs = None
             self.last_action = None

--- a/table_rl/learners/q_learning.py
+++ b/table_rl/learners/q_learning.py
@@ -38,7 +38,7 @@ class QLearning(learner.Learner):
             None
         """
         self.update_q(self.current_obs, self.last_action, reward, terminated, obs)
-        self.explorer.observe(obs, reward, terminated, truncated)
+        self.explorer.observe(obs, reward, terminated, truncated, training_mode)
         if terminated or truncated:
             self.current_obs = None
             self.last_action = None

--- a/tests/test_explorers.py
+++ b/tests/test_explorers.py
@@ -25,7 +25,7 @@ class TestEpsilonGreedyExplorers:
         for expected_epsilon in expected_epsilons:
             actual_epsilon = explorer.epsilon
             assert math.isclose(expected_epsilon, actual_epsilon)
-            explorer.observe(None, None, None, None)
+            explorer.observe(None, None, None, None, True)
 
 
     def test_pct_decay_epsilon_greedy(self):
@@ -35,8 +35,12 @@ class TestEpsilonGreedyExplorers:
         for expected_epsilon in expected_epsilons:
             actual_epsilon = explorer.epsilon
             assert math.isclose(actual_epsilon, expected_epsilon)
-            explorer.observe(None, None, None, None)
+            explorer.observe(None, None, None, None, True)
 
+    def test_not_training_mode(self):
+        explorer = table_rl.explorers.PercentageDecayEpsilonGreedy(1.0, 0.2, 0.8, 4)
+        for _ in range(100):
+            explorer.observe(None, None, None, None, True)
 
 class TestPolicyExecutor:
 


### PR DESCRIPTION
Currently the explorers observe method does not factor in whether or not the agent is in training mode. We only want to make modifications to the explorer in training mode, typically. This PR ensures that we can do that. The tests pass.